### PR TITLE
Add docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: shell
+
+shell:
+	docker exec -it mariadb-proxy /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3"
+
+services:
+  mariadb-server:
+    image: mariadb
+    container_name: mariadb-server
+    restart: always
+    environment:
+      - MYSQL_HOST=localhost
+      - MYSQL_PORT=3306
+      - MYSQL_ROOT_PASSWORD=devpassword
+    ports:
+      - "3306:3306"  # for interop with locahost
+
+  mariadb-proxy:
+    image: rust
+    container_name: mariadb-proxy
+    command: /bin/bash -c "while true; do sleep 200; echo 'TERMINAL is up'; done"
+    volumes:
+      - "./:/code"
+    working_dir: /code
+    ports:
+      - "26658:26658"
+    links:
+      - mariadb-server
+
+  tendermint:
+    image: tendermint/tendermint
+    container_name: tendermint-node
+    command: "node --proxy_app=tcp://mariadb-proxy:26658"
+    volumes:
+      - "/tmp/tendermint:/tendermint"
+    links:
+      - mariadb-server
+      - mariadb-proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
       - mariadb-server
 
   tendermint:
-    image: tendermint/tendermint
+    image: tendermint/tendermint:v0.32.9
     container_name: tendermint-node
-    command: "node --proxy_app=tcp://mariadb-proxy:26658"
+    entrypoint: /bin/sh -c "tendermint init && tendermint node --consensus.create_empty_blocks=false --proxy_app=tcp://mariadb-proxy:26658 --rpc.laddr=tcp://0.0.0.0:26657"
     volumes:
       - "/tmp/tendermint:/tendermint"
     links:


### PR DESCRIPTION
This PR attempts to consolidate the docker scripts into a single docker-compose setup. AFAIK, the `mariadb-proxy` container runs mariadb-proxy-rs which sends commands to `mariadb-server` and `tendermint`. I'm not totally clear on how TM makes its way in there; perhaps someone could clarify based on the `links` sections in the docker-compose.yml.

Omitted from `docker-compose` is the mysql client container since it requires sleeping for 30s before mariadb comes online, and then immediately exits as the terminal is non-interactive. I could use some help understanding where exactly the mysql client is used (if not exclusively from mariadb-proxy-rs). Is it for verifying that data has been committed? In that case, one can always `docker exec mariadb-server mysql --user=root --host=localhost --port=3306 --password=devpassword` and feed it commands. 

Otherwise, to run,
```
docker-compose up
```
and, to enter the `rust` container, `make shell`.

Currently, the tendermint container exits with a permission denied error, but that seems to be due to [this issue](https://gitter.im/stratumn/Lobby?at=5adf43036d7e07082b2b804c). If I had an example of how the integration tests use the proxy and TM, I'd be better able to get this part running.